### PR TITLE
Added support for ESP32

### DIFF
--- a/Microcontroller/Moppy2-Arduino/platformio.ini
+++ b/Microcontroller/Moppy2-Arduino/platformio.ini
@@ -14,7 +14,15 @@
 ; lib_deps=
 ;     FastLED ; For experimental lighting effects
 ;     https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
-	
+; upload_speed = 115200
+; monitor_speed = 115200
+
+; [env:esp32]
+; platform = espressif32
+; board = esp32dev
+; lib_deps=
+;    FastLED ; For experimental lighting effects
+;    https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
 ; upload_speed = 115200
 ; monitor_speed = 115200
 

--- a/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/FloppyDrives.cpp
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/FloppyDrives.cpp
@@ -171,6 +171,8 @@ Additionally, the ICACHE_RAM_ATTR helps avoid crashes with WiFi libraries, but m
 #pragma GCC optimize("Ofast") // Required to unroll this loop, but useful to try to keep this speedy
 #ifdef ARDUINO_ARCH_ESP8266
 void ICACHE_RAM_ATTR FloppyDrives::tick() {
+#elif ARDUINO_ARCH_ESP32
+void IRAM_ATTR FloppyDrives::tick() {
 #else
 void FloppyDrives::tick() {
 #endif
@@ -191,6 +193,8 @@ void FloppyDrives::tick() {
 
 #ifdef ARDUINO_ARCH_ESP8266
 void ICACHE_RAM_ATTR FloppyDrives::togglePin(byte driveNum, byte pin, byte direction_pin) {
+#elif ARDUINO_ARCH_ESP32
+void IRAM_ATTR FloppyDrives::togglePin(byte driveNum, byte pin, byte direction_pin) {
 #else
 void FloppyDrives::togglePin(byte driveNum, byte pin, byte direction_pin) {
 #endif

--- a/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/MoppyInstrument.h
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/MoppyInstrument.h
@@ -21,7 +21,7 @@
  */
 #ifdef ARDUINO_ARCH_AVR
 #define TIMER_RESOLUTION 40
-#elif ARDUINO_ARCH_ESP8266
+#elif ARDUINO_ARCH_ESP8266 || ARDUINO_ARCH_ESP32
 #define TIMER_RESOLUTION 20 // Higher resolution for the faster processor
 #endif
 

--- a/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/MoppyTimer.cpp
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/MoppyTimer.cpp
@@ -2,7 +2,7 @@
 
 #ifdef ARDUINO_ARCH_AVR
 #include <TimerOne.h>
-#elif ARDUINO_ARCH_ESP8266
+#elif ARDUINO_ARCH_ESP8266 || ARDUINO_ARCH_ESP32
 #include <Arduino.h>
 #endif
 
@@ -15,5 +15,10 @@ void MoppyTimer::initialize(unsigned long microseconds, void (*isr)()) {
     timer1_attachInterrupt(isr);
     timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
     timer1_write(5 * microseconds);
+#elif ARDUINO_ARCH_ESP32
+    hw_timer_t *timer = timerBegin(0, 80, true);
+    timerAttachInterrupt(timer, isr, true);
+    timerAlarmWrite(timer, microseconds, true);
+    timerAlarmEnable(timer);
 #endif
 }

--- a/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/ShiftedFloppyDrives.cpp
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyInstruments/ShiftedFloppyDrives.cpp
@@ -143,6 +143,8 @@ Additionally, the ICACHE_RAM_ATTR helps avoid crashes with WiFi libraries, but m
 #pragma GCC optimize("Ofast") // Required to unroll this loop, but useful to try to keep this speedy
 #ifdef ARDUINO_ARCH_ESP8266
 void ICACHE_RAM_ATTR ShiftedFloppyDrives::tick() {
+#elif ARDUINO_ARCH_ESP32
+void IRAM_ATTR ShiftedFloppyDrives::tick() {
 #else
 void ShiftedFloppyDrives::tick() {
 #endif
@@ -169,6 +171,8 @@ void ShiftedFloppyDrives::tick() {
 
 #ifdef ARDUINO_ARCH_ESP8266
 void ICACHE_RAM_ATTR ShiftedFloppyDrives::togglePin(byte driveIndex) {
+#elif ARDUINO_ARCH_ESP32
+void IRAM_ATTR ShiftedFloppyDrives::togglePin(byte driveIndex) {
 #else
 void ShiftedFloppyDrives::togglePin(byte driveIndex) {
 #endif
@@ -194,6 +198,8 @@ void ShiftedFloppyDrives::togglePin(byte driveIndex) {
 
 #ifdef ARDUINO_ARCH_ESP8266
 void ICACHE_RAM_ATTR ShiftedFloppyDrives::shiftBits() {
+#elif ARDUINO_ARCH_ESP32
+void IRAM_ATTR ShiftedFloppyDrives::shiftBits() {
 #else
 void ShiftedFloppyDrives::shiftBits() {
 #endif

--- a/Microcontroller/Moppy2-Arduino/src/MoppyNetworks/MoppyUDP.cpp
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyNetworks/MoppyUDP.cpp
@@ -1,6 +1,7 @@
 #include "MoppyUDP.h"
 
-#ifdef ARDUINO_ARCH_ESP8266 // For now, this will only work with ESP8266
+#if !defined ARDUINO_ARCH_ESP8266 && !defined ARDUINO_ARCH_ESP32
+#else
 
 WiFiUDP UDP;
 
@@ -31,7 +32,11 @@ bool MoppyUDP::startUDP() {
     Serial.println("");
     Serial.println("Connecting to UDP");
 
+#ifdef ARDUINO_ARCH_ESP8266
     if (UDP.beginMulticast(WiFi.localIP(), IPAddress(239, 2, 2, 7), MOPPY_UDP_PORT) == 1) {
+#elif ARDUINO_ARCH_ESP32
+    if (UDP.beginMulticast(IPAddress(239, 2, 2, 7), MOPPY_UDP_PORT) == 1) {
+#endif
         Serial.println("Connection successful");
         connected = true;
     } else {
@@ -139,4 +144,4 @@ void MoppyUDP::sendPong() {
     UDP.write(pongBytes, sizeof(pongBytes));
     UDP.endPacket();
 }
-#endif /* ARDUINO_ARCH_ESP8266 */
+#endif /* ARDUINO_ARCH_ESP8266 or ARDUINO_ARCH_ESP32 */

--- a/Microcontroller/Moppy2-Arduino/src/MoppyNetworks/MoppyUDP.h
+++ b/Microcontroller/Moppy2-Arduino/src/MoppyNetworks/MoppyUDP.h
@@ -2,7 +2,9 @@
  * MoppyUDP.h
  *
  */
-#ifdef ARDUINO_ARCH_ESP8266 // For now, this will only work with ESP8266
+#if !defined ARDUINO_ARCH_ESP8266 && !defined ARDUINO_ARCH_ESP32
+// For now, this will only work with ESP8266 or ESP32
+#else
 #ifndef SRC_MOPPYNETWORKS_MOPPYUDP_H_
 #define SRC_MOPPYNETWORKS_MOPPYUDP_H_
 
@@ -11,7 +13,11 @@
 #include "Arduino.h"
 #include "MoppyNetwork.h"
 #include <ArduinoOTA.h>
+#ifdef ARDUINO_ARCH_ESP8266
 #include <ESP8266WiFi.h>
+#elif ARDUINO_ARCH_ESP32
+#include <WiFi.h>
+#endif
 #include <ESPAsyncWebServer.h>   //Local WebServer used to serve the configuration portal
 #include <ESPAsyncWiFiManager.h> // https://github.com/alanswx/ESPAsyncWiFiManager WiFi Configuration Magic
 #include <WiFiUdp.h>
@@ -38,4 +44,4 @@ private:
 };
 
 #endif /* SRC_MOPPYNETWORKS_MOPPYUDP_H_ */
-#endif /* ARDUINO_ARCH_ESP8266 */
+#endif /* ARDUINO_ARCH_ESP8266 or ARDUINO_ARCH_ESP32 */


### PR DESCRIPTION
Hi Sammy1Am, thank you for launching this awesome project. I've added support for ESP32 - in essence, I've added new preprocessor macros for the ESP32 specific things and ported the timer.

It's running well on my ESP32 module with INSTRUMENT_SHIFTED_FLOPPIES and NETWORK_UDP, but should also work with other instruments and networks. Of cause, it will require defining valid pins.

Since ESP32 modules usually have two cores, one could certainly optimize this and use the FreeRTOS to schedule the tick method and the readMessages method on different cores. But I am just starting to get to know the ESP platform, so I didn't look into this yet.