### PR TITLE
Default envs

### DIFF
--- a/Microcontroller/Moppy2-Arduino/README.md
+++ b/Microcontroller/Moppy2-Arduino/README.md
@@ -2,5 +2,6 @@
 Device implementation for Moppy2 for microcontrollers that support the Arduino **framework**.  Currently, the following boards are officially supported:
 - **Arduino [Uno\*]** (via the Arduino IDE or PlatformIO)
 - **ESP8266** (via PlatformIO)
+- **ESP32** (via PlatformIO)
 
 \* Most "Arduino" boards are extremely similar and should work fine, though if you're using PlatformIO you may need to modify `platformio.ini` to match your board-type.

--- a/Microcontroller/Moppy2-Arduino/platformio.ini
+++ b/Microcontroller/Moppy2-Arduino/platformio.ini
@@ -8,31 +8,33 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-; [env:esp12e]
-; platform = espressif8266
-; board = esp12e
-; lib_deps=
-;     FastLED ; For experimental lighting effects
-;     https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
-; upload_speed = 115200
-; monitor_speed = 115200
+[platformio]
+default_envs = uno
 
-; [env:esp32]
-; platform = espressif32
-; board = esp32dev
-; lib_deps=
-;    FastLED ; For experimental lighting effects
-;    https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
-; upload_speed = 115200
-; monitor_speed = 115200
+[env]
+framework = arduino
 
 [env:uno]
 platform = atmelavr
 board = uno
 lib_deps=
-    TimerOne
-
+   TimerOne
 monitor_speed = 57600
 
-[env]
-framework = arduino
+[env:esp12e]
+platform = espressif8266
+board = esp12e
+lib_deps=
+    FastLED ; For experimental lighting effects
+    https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
+upload_speed = 115200
+monitor_speed = 115200
+
+[env:esp32]
+platform = espressif32
+board = esp32dev
+lib_deps=
+    FastLED ; For experimental lighting effects
+    https://github.com/sstaub/Ticker ; For experimental lighting effects (because lights are too slow for Timer)
+upload_speed = 115200
+monitor_speed = 115200


### PR DESCRIPTION
Hi @Sammy1Am,

I once again have a little pull request. When you mentioned yesterday that you like that the default setting is still Arduino Uno, I thought "There must be a way to do this without having to comment out lines all the time.".

PlatformIO has a `default_envs` option, which seems to be really useful for this. It's still set to use Uno environment by default, but one can now simply use the _PlatformIO: Switch Project Environment_ command of the PlatformIO IDE for changing the build environment:
![grafik](https://user-images.githubusercontent.com/8090259/104091667-0568a380-527f-11eb-8a48-d770dc6e9a43.png)

There is also an extra button in the bottom toolbar for this:
![grafik](https://user-images.githubusercontent.com/8090259/104091695-3ba62300-527f-11eb-94a7-e6343a95cc9f.png)