### PR TITLE
Update MoppyControlGUI dependencies & add temporary IntelliJ files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 
 # Gradle Artifacts #
 **/.gradle/**
+**/gradle/**
+gradle
+gradlew
+gradlew.bat
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
@@ -41,3 +45,6 @@ Java/*/.settings/org.eclipse.jdt.core.prefs
 Java/*/.settings/org.eclipse.buildship.core.prefs
 Java/MoppyControlGUI/**/*.form
 **/.vscode
+
+# JetBrains IntelliJ
+.idea

--- a/Java/MoppyControlGUI/build.gradle
+++ b/Java/MoppyControlGUI/build.gradle
@@ -33,9 +33,9 @@ repositories {
 
 dependencies {
     implementation project(':MoppyLib')
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
-    compileOnly 'org.projectlombok:lombok:1.18.12'
-    annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    compileOnly 'org.projectlombok:lombok:1.18.34'
+    annotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     // Use JUnit test framework
     //testImplementation 'junit:junit:4.12'

--- a/Java/MoppyLib/build.gradle
+++ b/Java/MoppyLib/build.gradle
@@ -19,10 +19,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fazecast:jSerialComm:2.6.+'
-    api 'org.graalvm.js:js:20.1.+'
-    compileOnly 'org.projectlombok:lombok:1.18.12'
-    annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    implementation 'com.fazecast:jSerialComm:2.11.+'
+    api 'org.graalvm.js:js:23.0.+'
+    compileOnly 'org.projectlombok:lombok:1.18.34'
+    annotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     // Use JUnit test framework
     //testImplementation 'junit:junit:4.+'


### PR DESCRIPTION
Updates all dependencies in the MoppyControlGUI and MoppyLib to their latest version.
I also included the names of the temporary files which were generated by IntelliJ in the .gitignore, so they won't be uploaded anymore.